### PR TITLE
feat(sablier): add extraArgs value for extra CLI flags

### DIFF
--- a/charts/sablier/Chart.yaml
+++ b/charts/sablier/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sablier
-version: 1.0.3
+version: 1.1.0
 appVersion: "1.8.1"
 description: A free and open-source software to start workloads on demand and stop them after a period of inactivity.
 type: application

--- a/charts/sablier/README.md
+++ b/charts/sablier/README.md
@@ -1,15 +1,12 @@
 # sablier
 
-
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square) 
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
 
 A free and open-source software to start workloads on demand and stop them after a period of inactivity.
 
 ## Source Code
 
 * <https://github.com/sablierapp/sablier>
-
-
 
 ## Get Repo Info
 
@@ -49,6 +46,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | deploymentAnnotations | object | `{}` | Annotations for all deployed Deployments |
 | deploymentLabels | object | `{}` | Labels for all deployed Deployments |
 | deploymentStrategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | Deployment strategy for all deployed Deployments |
+| extraArgs | list | `[]` | Extra CLI arguments appended to the sablier container args (e.g. - --server.metrics.enabled=true to expose Prometheus /metrics) |
 | image.repository | string | `"sablierapp/sablier"` | Sablier image repository |
 | image.tag | string | `""` | Sablier image tag (deafult) appVersion |
 | imagePullPolicy | string | `"IfNotPresent"` | Sablier imagePullPolicy |

--- a/charts/sablier/templates/deployment.yaml
+++ b/charts/sablier/templates/deployment.yaml
@@ -38,7 +38,13 @@ spec:
         - name: sablier
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: IfNotPresent
-          args: ["start", "--provider.name=kubernetes", "--logging.level={{ .Values.logLevel}}"]
+          args:
+            - start
+            - --provider.name=kubernetes
+            - --logging.level={{ .Values.logLevel }}
+          {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 10000
         {{- with .Values.livenessProbe }}

--- a/charts/sablier/values.yaml
+++ b/charts/sablier/values.yaml
@@ -23,6 +23,10 @@ replicas: 1
 # -- Sablier log level
 logLevel: "trace"
 
+# -- Extra CLI arguments appended to the sablier container args
+# (e.g. - --server.metrics.enabled=true to expose Prometheus /metrics)
+extraArgs: []
+
 image:
   # -- Sablier image repository
   repository: "sablierapp/sablier"


### PR DESCRIPTION
## Summary

Adds an `extraArgs` value to the `sablier` chart so users can pass additional CLI flags to the sablier container without forking the chart or post-rendering.

The motivating use case is enabling the Prometheus `/metrics` endpoint (`--server.metrics.enabled=true`, default `false` in sablier). Today there is no way to flip this through the chart — args are hardcoded in `templates/deployment.yaml` and there is no `extraArgs`/`env` escape hatch. Scrape annotations were already supported via `podAnnotations`, so this single addition + a Prometheus annotation set is enough to wire metrics scraping end-to-end:

```yaml
extraArgs:
  - --server.metrics.enabled=true
podAnnotations:
  prometheus.io/scrape: "true"
  prometheus.io/port: "10000"
  prometheus.io/path: "/metrics"
```

The same value can be used for any other future CLI flag, keeping the chart's surface minimal (just one escape hatch instead of a dedicated boolean per feature).

## Changes

- `values.yaml`: new `extraArgs: []` (documented).
- `templates/deployment.yaml`: container `args` converted from inline-array to block form and `extraArgs` appended via `toYaml | nindent`.
- `Chart.yaml`: `version` bumped `1.0.3` → `1.1.0` (additive, non-breaking).
- `README.md`: regenerated with `helm-docs v1.14.2` per CONTRIBUTING.md.

Default (`extraArgs: []`) renders identical args to the current chart, so existing installs are unaffected.

## Test plan

- [x] `helm lint charts/sablier` passes
- [x] `helm template test charts/sablier` (default values) renders args identical to the pre-change chart
- [x] `helm template test charts/sablier --set 'extraArgs={--server.metrics.enabled=true,--foo=bar}'` renders both extra flags appended to the args list
- [x] `helm-docs v1.14.2` produces the committed README
- [x] DCO sign-off on the commit

## Rendered diff (relevant excerpt)

With `extraArgs: [--server.metrics.enabled=true]`:

```yaml
args:
  - start
  - --provider.name=kubernetes
  - --logging.level=trace
  - --server.metrics.enabled=true
```

With default `extraArgs: []`:

```yaml
args:
  - start
  - --provider.name=kubernetes
  - --logging.level=trace
```